### PR TITLE
Additional pipeline examples and some fixes

### DIFF
--- a/sysdig/sysdigpipeline.yaml
+++ b/sysdig/sysdigpipeline.yaml
@@ -253,7 +253,7 @@ metadata:
 spec:
   pipelineRef:
     name: demo-pipeline
-  serviceAccount: 'default'
+  serviceAccountName: 'default'
   resources:
   - name: source-repo
     resourceRef:

--- a/sysdig/sysdigpipeline.yaml
+++ b/sysdig/sysdigpipeline.yaml
@@ -103,7 +103,7 @@ spec:
     # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
     env:
     - name: "DOCKER_CONFIG"
-      value: "/builder/home/.docker/"
+      value: "/tekton/home/.docker/"
     command:
     - /kaniko/executor
     args:

--- a/sysdig/sysdigpipeline2.yaml
+++ b/sysdig/sysdigpipeline2.yaml
@@ -1,0 +1,347 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: docker-auth-for-tekton
+  annotations:
+    tekton.dev/docker-0: https://index.docker.io
+    tekton.dev/docker-1: https://gcr.io
+type: kubernetes.io/basic-auth
+stringData:
+  username: <username>
+  password: <password>
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-bot
+secrets:
+  - name: docker-auth-for-tekton
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: build-bot-tekton-pipelines-admin
+  namespace: tekton-pipelines
+subjects:
+- kind: User
+  name: build-bot
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: tekton-pipelines-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: build-bot-deploy-role
+  namespace: tekton-pipelines
+rules:
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments"]
+  verbs: ["get", "create", "update", "patch"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "create", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: build-bot-deploy-binding
+  namespace: tekton-pipelines
+subjects:
+- kind: ServiceAccount
+  name: build-bot
+  namespace: tekton-pipelines
+roleRef:
+  kind: Role
+  name: build-bot-deploy-role
+  apiGroup: rbac.authorization.k8s.io
+---
+
+# ===================================================
+
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: unit-tests
+spec:
+  inputs:
+    resources:
+    - name: workspace
+      type: git
+      targetPath: go/src/github.com/GoogleContainerTools/skaffold
+  steps:
+  - name: run-tests
+    image: golang
+    env:
+    - name: GOPATH
+      value: /workspace/go
+    workingDir: /workspace/go/src/github.com/GoogleContainerTools/skaffold
+    command:
+    - echo
+    args:
+    - "pass"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: build-push
+spec:
+  inputs:
+    resources:
+    - name: workspace
+      type: git
+    params:
+    - name: pathToDockerFile
+      description: The path to the dockerfile to build
+      default: /workspace/workspace/Dockerfile
+    - name: pathToContext
+      description: The build context used by Kaniko (https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
+      default: /workspace/workspace
+  outputs:
+    resources:
+    - name: builtImage
+      type: image
+  steps:
+  - name: build-and-push
+    image: gcr.io/kaniko-project/executor:v0.9.0
+    # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
+    env:
+    - name: "DOCKER_CONFIG"
+      value: "/tekton/home/.docker/"
+    command:
+    - /kaniko/executor
+    args:
+    - --dockerfile=$(inputs.params.pathToDockerFile)
+    - --destination=$(outputs.resources.builtImage.url)
+    - --context=$(inputs.params.pathToContext)
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: scan-image
+spec:
+  inputs:
+    resources:
+    - name: image
+      type: image
+  steps:
+  - name: scan-image-step
+    image: sysdiglabs/secure-image-scanning:latest
+    env:
+    - name: IMAGE_TO_SCAN
+      value: $(inputs.resources.image.url)
+    - name: SYSDIG_SECURE_TOKEN
+      value: <your_sysdig_secure_token>
+---
+#This task deploys with kubectl apply -f <filename>
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: demo-deploy-kubectl
+spec:
+  inputs:
+    resources:
+    - name: workspace
+      type: git
+    - name: image
+      type: image
+    params:
+    - name: path
+      description: Path to the manifest to apply
+    - name: yqArg
+      description: Okay this is a hack, but I didn't feel right hard-codeing `-d1` down below
+    - name: yamlPathToImage
+      description: The path to the image to replace in the yaml manifest (arg to yq)
+  steps:
+  - name: replace-image
+    image: mikefarah/yq
+    command: ['yq']
+    args:
+    - "w"
+    - "-i"
+    - "$(inputs.params.yqArg)"
+    - "$(inputs.params.path)"
+    - "$(inputs.params.yamlPathToImage)"
+    - "$(inputs.resources.image.url)"
+  - name: run-kubectl
+    image: lachlanevenson/k8s-kubectl
+    command: ['kubectl']
+    args:
+    - 'apply'
+    - '-f'
+    - '$(inputs.params.path)'
+---
+# This Pipeline Builds two microservice images(https://github.com/GoogleContainerTools/skaffold/tree/master/examples/microservices)
+# from the Skaffold repo (https://github.com/GoogleContainerTools/skaffold) and deploys them to the repo currently running Tekton Pipelines.
+
+# **Note** : It does this using the k8s `Deployment` in the skaffold repos's existing yaml
+# files, so at the moment there is no guarantee that the image that are built and
+# pushed are the ones that are deployed (that would require using the digest of
+# the built image, see https://github.com/tektoncd/pipeline/issues/216).
+
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: demo-pipeline
+spec:
+  resources:
+  - name: source-repo
+    type: git
+  - name: web-image
+    type: image
+  - name: app-image
+    type: image
+  tasks:
+  - name: skaffold-unit-tests
+    taskRef:
+      name: unit-tests
+    resources:
+      inputs:
+      - name: workspace
+        resource: source-repo
+  - name: build-skaffold-web
+    runAfter: [skaffold-unit-tests]
+    taskRef:
+      name: build-push
+    params:
+    - name: pathToDockerFile
+      value: Dockerfile
+    - name: pathToContext
+      value: /workspace/workspace/examples/microservices/leeroy-web
+    resources:
+      inputs:
+      - name: workspace
+        resource: source-repo
+      outputs:
+      - name: builtImage
+        resource: web-image
+  - name: build-skaffold-app
+    runAfter: [skaffold-unit-tests]
+    taskRef:
+      name: build-push
+    params:
+    - name: pathToDockerFile
+      value: Dockerfile
+    - name: pathToContext
+      value: /workspace/workspace/examples/microservices/leeroy-app
+    resources:
+      inputs:
+      - name: workspace
+        resource: source-repo
+      outputs:
+      - name: builtImage
+        resource: app-image
+  - name: scan-image-web
+    runAfter: [build-skaffold-web]
+    taskRef:
+      name: scan-image
+    resources:
+      inputs:
+      - name: image
+        resource: web-image
+        from:
+        - build-skaffold-web
+  - name: scan-image-app
+    runAfter: [build-skaffold-app]
+    taskRef:
+      name: scan-image
+    resources:
+      inputs:
+      - name: image
+        resource: app-image
+        from:
+        - build-skaffold-app
+  - name: deploy-app
+    runAfter: [scan-image-app]
+    taskRef:
+      name: demo-deploy-kubectl
+    resources:
+      inputs:
+      - name: workspace
+        resource: source-repo
+      - name: image
+        resource: app-image
+        from:
+        - build-skaffold-app
+    params:
+    - name: path
+      value: /workspace/workspace/examples/microservices/leeroy-app/kubernetes/deployment.yaml
+    - name: yqArg
+      value: "-d1"
+    - name: yamlPathToImage
+      value: "spec.template.spec.containers[0].image"
+  - name: deploy-web
+    runAfter: [scan-image-web]
+    taskRef:
+      name: demo-deploy-kubectl
+    resources:
+      inputs:
+      - name: workspace
+        resource: source-repo
+      - name: image
+        resource: web-image
+        from:
+        - build-skaffold-web
+    params:
+    - name: path
+      value: /workspace/workspace/examples/microservices/leeroy-web/kubernetes/deployment.yaml
+    - name: yqArg
+      value: "-d1"
+    - name: yamlPathToImage
+      value: "spec.template.spec.containers[0].image"
+---
+
+# =================================================
+
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-image-leeroy-app
+spec:
+  type: image
+  params:
+  - name: url
+    value: gcr.io/christiewilson-catfactory/leeroy-app
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-image-leeroy-web-pipelinerun
+spec:
+  type: image
+  params:
+  - name: url
+    value: gcr.io/christiewilson-catfactory/leeroy-web
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-git-pipelinerun
+spec:
+  type: git
+  params:
+  - name: revision
+    value: v0.32.0
+  - name: url
+    value: https://github.com/GoogleContainerTools/skaffold
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: demo-pipeline-run-1
+spec:
+  pipelineRef:
+    name: demo-pipeline
+  serviceAccountName: build-bot
+  resources:
+  - name: source-repo
+    resourceRef:
+      name: skaffold-git-pipelinerun
+  - name: web-image
+    resourceRef:
+      name: skaffold-image-leeroy-web-pipelinerun
+  - name: app-image
+    resourceRef:
+      name: skaffold-image-leeroy-app

--- a/sysdig/sysdigpipelineblock.yaml
+++ b/sysdig/sysdigpipelineblock.yaml
@@ -253,7 +253,7 @@ metadata:
 spec:
   pipelineRef:
     name: demo-pipeline
-  serviceAccount: 'default'
+  serviceAccountName: 'default'
   resources:
   - name: source-repo
     resourceRef:

--- a/sysdig/sysdigpipelineblock.yaml
+++ b/sysdig/sysdigpipelineblock.yaml
@@ -103,7 +103,7 @@ spec:
     # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
     env:
     - name: "DOCKER_CONFIG"
-      value: "/builder/home/.docker/"
+      value: "/tekton/home/.docker/"
     command:
     - /kaniko/executor
     args:

--- a/sysdig/sysdigpipelineblock2.yaml
+++ b/sysdig/sysdigpipelineblock2.yaml
@@ -1,0 +1,347 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: docker-auth-for-tekton
+  annotations:
+    tekton.dev/docker-0: https://index.docker.io
+    tekton.dev/docker-1: https://gcr.io
+type: kubernetes.io/basic-auth
+stringData:
+  username: <username>
+  password: <password>
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-bot
+secrets:
+  - name: docker-auth-for-tekton
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: build-bot-tekton-pipelines-admin
+  namespace: tekton-pipelines
+subjects:
+- kind: User
+  name: build-bot
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: tekton-pipelines-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: build-bot-deploy-role
+  namespace: tekton-pipelines
+rules:
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments"]
+  verbs: ["get", "create", "update", "patch"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "create", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: build-bot-deploy-binding
+  namespace: tekton-pipelines
+subjects:
+- kind: ServiceAccount
+  name: build-bot
+  namespace: tekton-pipelines
+roleRef:
+  kind: Role
+  name: build-bot-deploy-role
+  apiGroup: rbac.authorization.k8s.io
+---
+
+# ===================================================
+
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: unit-tests
+spec:
+  inputs:
+    resources:
+    - name: workspace
+      type: git
+      targetPath: go/src/github.com/GoogleContainerTools/skaffold
+  steps:
+  - name: run-tests
+    image: golang
+    env:
+    - name: GOPATH
+      value: /workspace/go
+    workingDir: /workspace/go/src/github.com/GoogleContainerTools/skaffold
+    command:
+    - echo
+    args:
+    - "pass"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: build-push
+spec:
+  inputs:
+    resources:
+    - name: workspace
+      type: git
+    params:
+    - name: pathToDockerFile
+      description: The path to the dockerfile to build
+      default: /workspace/workspace/Dockerfile
+    - name: pathToContext
+      description: The build context used by Kaniko (https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
+      default: /workspace/workspace
+  outputs:
+    resources:
+    - name: builtImage
+      type: image
+  steps:
+  - name: build-and-push
+    image: gcr.io/kaniko-project/executor:v0.9.0
+    # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
+    env:
+    - name: "DOCKER_CONFIG"
+      value: "/tekton/home/.docker/"
+    command:
+    - /kaniko/executor
+    args:
+    - --dockerfile=$(inputs.params.pathToDockerFile)
+    - --destination=$(outputs.resources.builtImage.url)
+    - --context=$(inputs.params.pathToContext)
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: scan-image
+spec:
+  inputs:
+    resources:
+    - name: image
+      type: image
+  steps:
+  - name: scan-image-step
+    image: sysdiglabs/secure-image-scanning:latest
+    env:
+    - name: IMAGE_TO_SCAN
+      value: quay.io/marcf5/mltitanic
+    - name: SYSDIG_SECURE_TOKEN
+      value: <your_sysdig_secure_token>
+---
+#This task deploys with kubectl apply -f <filename>
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: demo-deploy-kubectl
+spec:
+  inputs:
+    resources:
+    - name: workspace
+      type: git
+    - name: image
+      type: image
+    params:
+    - name: path
+      description: Path to the manifest to apply
+    - name: yqArg
+      description: Okay this is a hack, but I didn't feel right hard-codeing `-d1` down below
+    - name: yamlPathToImage
+      description: The path to the image to replace in the yaml manifest (arg to yq)
+  steps:
+  - name: replace-image
+    image: mikefarah/yq
+    command: ['yq']
+    args:
+    - "w"
+    - "-i"
+    - "$(inputs.params.yqArg)"
+    - "$(inputs.params.path)"
+    - "$(inputs.params.yamlPathToImage)"
+    - "$(inputs.resources.image.url)"
+  - name: run-kubectl
+    image: lachlanevenson/k8s-kubectl
+    command: ['kubectl']
+    args:
+    - 'apply'
+    - '-f'
+    - '$(inputs.params.path)'
+---
+# This Pipeline Builds two microservice images(https://github.com/GoogleContainerTools/skaffold/tree/master/examples/microservices)
+# from the Skaffold repo (https://github.com/GoogleContainerTools/skaffold) and deploys them to the repo currently running Tekton Pipelines.
+
+# **Note** : It does this using the k8s `Deployment` in the skaffold repos's existing yaml
+# files, so at the moment there is no guarantee that the image that are built and
+# pushed are the ones that are deployed (that would require using the digest of
+# the built image, see https://github.com/tektoncd/pipeline/issues/216).
+
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: demo-pipeline
+spec:
+  resources:
+  - name: source-repo
+    type: git
+  - name: web-image
+    type: image
+  - name: app-image
+    type: image
+  tasks:
+  - name: skaffold-unit-tests
+    taskRef:
+      name: unit-tests
+    resources:
+      inputs:
+      - name: workspace
+        resource: source-repo
+  - name: build-skaffold-web
+    runAfter: [skaffold-unit-tests]
+    taskRef:
+      name: build-push
+    params:
+    - name: pathToDockerFile
+      value: Dockerfile
+    - name: pathToContext
+      value: /workspace/workspace/examples/microservices/leeroy-web
+    resources:
+      inputs:
+      - name: workspace
+        resource: source-repo
+      outputs:
+      - name: builtImage
+        resource: web-image
+  - name: build-skaffold-app
+    runAfter: [skaffold-unit-tests]
+    taskRef:
+      name: build-push
+    params:
+    - name: pathToDockerFile
+      value: Dockerfile
+    - name: pathToContext
+      value: /workspace/workspace/examples/microservices/leeroy-app
+    resources:
+      inputs:
+      - name: workspace
+        resource: source-repo
+      outputs:
+      - name: builtImage
+        resource: app-image
+  - name: scan-image-web
+    runAfter: [build-skaffold-web]
+    taskRef:
+      name: scan-image
+    resources:
+      inputs:
+      - name: image
+        resource: web-image
+        from:
+        - build-skaffold-web
+  - name: scan-image-app
+    runAfter: [build-skaffold-app]
+    taskRef:
+      name: scan-image
+    resources:
+      inputs:
+      - name: image
+        resource: app-image
+        from:
+        - build-skaffold-app
+  - name: deploy-app
+    runAfter: [scan-image-app]
+    taskRef:
+      name: demo-deploy-kubectl
+    resources:
+      inputs:
+      - name: workspace
+        resource: source-repo
+      - name: image
+        resource: app-image
+        from:
+        - build-skaffold-app
+    params:
+    - name: path
+      value: /workspace/workspace/examples/microservices/leeroy-app/kubernetes/deployment.yaml
+    - name: yqArg
+      value: "-d1"
+    - name: yamlPathToImage
+      value: "spec.template.spec.containers[0].image"
+  - name: deploy-web
+    runAfter: [scan-image-web]
+    taskRef:
+      name: demo-deploy-kubectl
+    resources:
+      inputs:
+      - name: workspace
+        resource: source-repo
+      - name: image
+        resource: web-image
+        from:
+        - build-skaffold-web
+    params:
+    - name: path
+      value: /workspace/workspace/examples/microservices/leeroy-web/kubernetes/deployment.yaml
+    - name: yqArg
+      value: "-d1"
+    - name: yamlPathToImage
+      value: "spec.template.spec.containers[0].image"
+---
+
+# =================================================
+
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-image-leeroy-app
+spec:
+  type: image
+  params:
+  - name: url
+    value: gcr.io/christiewilson-catfactory/leeroy-app
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-image-leeroy-web-pipelinerun
+spec:
+  type: image
+  params:
+  - name: url
+    value: gcr.io/christiewilson-catfactory/leeroy-web
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: skaffold-git-pipelinerun
+spec:
+  type: git
+  params:
+  - name: revision
+    value: v0.32.0
+  - name: url
+    value: https://github.com/GoogleContainerTools/skaffold
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: demo-pipeline-run-1
+spec:
+  pipelineRef:
+    name: demo-pipeline
+  serviceAccountName: build-bot
+  resources:
+  - name: source-repo
+    resourceRef:
+      name: skaffold-git-pipelinerun
+  - name: web-image
+    resourceRef:
+      name: skaffold-image-leeroy-web-pipelinerun
+  - name: app-image
+    resourceRef:
+      name: skaffold-image-leeroy-app

--- a/sysdig/tekton/README.adoc
+++ b/sysdig/tekton/README.adoc
@@ -106,6 +106,45 @@ Last Eval: 2019-10-23T23:32:53Z
 Policy ID: default
 ----
 
+== Example scanning after building image
+
+For an example that uses a service account with specific permissions to deploy to the namespace, and a pipeline that first builds and pushes the image to registry, and then scan each image using Sysdig Secure, use sysdigpipeline2.yaml and sysdigpipeline2block.yaml.
+
+You will need to do some modifications to the files:
+
+* At the beginning, replace `<username>` and `<password>` with your Docker Hub or Google Registry credentials.
+* Replace `<your_sysdig_secure_token>` with your Sysdig API token
+* Replace the destination url of the built images to one available in your registry, at:
+  * `gcr.io/christiewilson-catfactory/leeroy-web`
+  * `gcr.io/christiewilson-catfactory/leeroy-web`
+If you use docker for those registries, start the URL with `index.docker.io`
+
+oc create   -f sysdigpipeline2.yaml
+
+Wait until the pipeline finishes running.
+
+oc get pods
+
+```
+NAME                                                      READY   STATUS      RESTARTS   AGE
+demo-pipeline-run-1-build-skaffold-app-nf42x-pod-fwxrs    0/4     Completed   0          14m
+demo-pipeline-run-1-build-skaffold-web-gz6cm-pod-wrd47    0/4     Completed   0          14m
+demo-pipeline-run-1-deploy-app-nzv88-pod-9c2mw            0/3     Completed   0          10m
+demo-pipeline-run-1-deploy-web-xgmmw-pod-6b4ml            0/3     Completed   0          10m
+demo-pipeline-run-1-scan-image-app-cbc2r-pod-qfj6x        0/1     Completed   0          12m
+demo-pipeline-run-1-scan-image-web-c97ct-pod-hmfl7        0/1     Completed   0          12m
+demo-pipeline-run-1-skaffold-unit-tests-qrf2j-pod-5l8qh   0/2     Completed   0          16m
+leeroy-app-7564dffd66-vdgjm                               1/1     Running     0          10m
+leeroy-web-546778548d-5th9c                               1/1     Running     0          10m
+tekton-pipelines-controller-dcf84f645-rtvcg               1/1     Running     0          59m
+tekton-pipelines-webhook-74d55ccdcf-bmhww                 1/1     Running     0          59m
+```
+
+
+
+
+
+
 
 
 

--- a/sysdig/tekton/README.adoc
+++ b/sysdig/tekton/README.adoc
@@ -25,7 +25,7 @@ OpenShift version: 4.2.0 (embedded in binary)
 ----
 oc new-project tekton-pipelines
 oc adm policy add-scc-to-user anyuid -z tekton-pipelines-controller
-oc apply --filename https://storage.googleapis.com/tekton-releases/latest/release.yaml
+oc apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.notags.yaml
 ----
 
 == Check Tekton is successfully installed


### PR DESCRIPTION
This PR includes a couple of fixes to the sample Tekton pipeline definitions using Sysdig:
* Changed URL for deploying Tekton to the `notags` variant.
* Changed directory name for registry config from build/.docker to the right one tekton/.docker
* Changed use of ServiceAccountName instead of ServiceAccount in PipelineRun

It also introduces an additional pipeline definition with a blocking variant, that uses a service account with specific permissions to deploy on the namespace, and has the image scanning with Sysdig step after build&push in its own task, using the built image for scanning. It also provides information about how to modify default values to run it on README.adoc.

I have preferred to leave this modification as a separate sample, as the original one can be a simple first step to be able to test the Sysdig image scanning step. But could otherwise be integrated as the main example, rewriting some parts of the tutorial.